### PR TITLE
Add fitted memory/runtime models and resource schema

### DIFF
--- a/memory_model.json
+++ b/memory_model.json
@@ -1,0 +1,19 @@
+{
+  "features": [
+    {
+      "coefficient": 1.0,
+      "exponent": 0.918895793153508,
+      "kind": "Feature",
+      "name": "n_cols"
+    },
+    {
+      "coefficient": 1.0,
+      "exponent": 0.3136082890218223,
+      "kind": "Feature",
+      "name": "n_rows"
+    }
+  ],
+  "intercept": 0.007600336047617048,
+  "kind": "OperatorEstimateModel",
+  "offset": 238.4933203125
+}

--- a/resource_model_schema.json
+++ b/resource_model_schema.json
@@ -1,0 +1,10 @@
+{
+  "kind": "ResourceModelSchema",
+  "design": "corners_center",
+  "memory_features": ["observation", "variable", "observation_||_variable"],
+  "runtime_features": ["observation", "variable", "observation_||_variable"],
+  "sweep": {
+    "observation": {"min": 200, "max": 1000000},
+    "variable":    {"min": 10,  "max": 60}
+  }
+}

--- a/runtime_model.json
+++ b/runtime_model.json
@@ -1,0 +1,19 @@
+{
+  "features": [
+    {
+      "coefficient": 1.0,
+      "exponent": 0.9062237839578154,
+      "kind": "Feature",
+      "name": "n_cols"
+    },
+    {
+      "coefficient": 1.0,
+      "exponent": 0.432170235695855,
+      "kind": "Feature",
+      "name": "n_rows"
+    }
+  ],
+  "intercept": 0.0004117019449474445,
+  "kind": "OperatorEstimateModel",
+  "offset": 6.8381577
+}


### PR DESCRIPTION
## Summary
- Adds `memory_model.json` and `runtime_model.json` (power-law coefficients produced by sarno's sweep fitter).
- Adds `resource_model_schema.json` describing the sweep design (corners_center, observation 200–1M × variable 10–60) used to generate the fits.

## What this enables
With these files present, Tercen's `git_operator.dart` loads them at install time into `Operator.memoryModel` / `Operator.runtimeModel`. The scheduler's `_calculateMemoryEstimate` then produces `stats_d_estimated_ram` / `stats_d_estimated_runtime` from the model instead of the legacy `base_memory + size × ratio` fallback.

## Validation
- Local dev (crabs, 200×5): estimate 359 MiB, actual peak 290 MiB → `×1.5` safety covers a ~15% raw-formula undershoot.
- Stage cytometry (OMIP, 4000×46): estimate 409 MiB, actual peak 285 MiB.

## Risk
Pure additive — no change to `main.R`, `operator.json`, or the R runtime. Operators without these files continue on the legacy path; operators with them use the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)